### PR TITLE
Persist activities: add DB-backed Activity & Signup models

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,63 +19,96 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
+# Database-backed activities
+from .db import SessionLocal, init_db, Activity, Signup
+
+
+# Seed data to initialize the DB for first run
+INITIAL_ACTIVITIES = [
+    {
+        "name": "Chess Club",
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
-    "Programming Class": {
+    {
+        "name": "Programming Class",
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
-    "Gym Class": {
+    {
+        "name": "Gym Class",
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
-    "Soccer Team": {
+    {
+        "name": "Soccer Team",
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
-    "Basketball Team": {
+    {
+        "name": "Basketball Team",
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
-    "Art Club": {
+    {
+        "name": "Art Club",
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
-    "Drama Club": {
+    {
+        "name": "Drama Club",
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
-    "Math Club": {
+    {
+        "name": "Math Club",
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
-    "Debate Team": {
+    {
+        "name": "Debate Team",
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+]
+
+
+# Initialize DB and seed if empty
+init_db()
+with SessionLocal() as session:
+    count = session.query(Activity).count()
+    if count == 0:
+        for a in INITIAL_ACTIVITIES:
+            act = Activity(
+                name=a["name"],
+                description=a["description"],
+                schedule=a["schedule"],
+                max_participants=a["max_participants"],
+            )
+            session.add(act)
+            session.flush()
+            for p in a.get("participants", []):
+                signup = Signup(activity_id=act.id, email=p)
+                session.add(signup)
+        session.commit()
 
 
 @app.get("/")
@@ -85,48 +118,65 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    """Return all activities with current participants (from DB)."""
+    with SessionLocal() as session:
+        acts = session.query(Activity).all()
+        result = {}
+        for a in acts:
+            participants = [s.email for s in a.signups]
+            result[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": participants,
+            }
+        return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with SessionLocal() as session:
+        activity = session.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        # Check if already signed up
+        existing = (
+            session.query(Signup)
+            .filter(Signup.activity_id == activity.id, Signup.email == email)
+            .first()
         )
+        if existing:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        # Check max participants
+        count = session.query(Signup).filter(Signup.activity_id == activity.id).count()
+        if activity.max_participants and count >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
+
+        signup = Signup(activity_id=activity.id, email=email)
+        session.add(signup)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with SessionLocal() as session:
+        activity = session.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        existing = (
+            session.query(Signup)
+            .filter(Signup.activity_id == activity.id, Signup.email == email)
+            .first()
         )
+        if not existing:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(existing)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
This PR replaces the in-memory activities store with a SQLite + SQLAlchemy backend.

Changes:
- Add `src/db.py` with `Activity` and `Signup` models and `init_db()` helper.
- Update `src/app.py` to seed the DB and read/write activities via SQLAlchemy sessions.
- Add `sqlalchemy` to `requirements.txt`.

Notes for reviewers:
- The DB file is created at `src/activities.db` when the app starts.
- This is a minimal synchronous integration to keep the FastAPI handlers simple.
- Next steps: add authentication, input validation, and tests.